### PR TITLE
Improve reading time estimates and fix generated page links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,11 +25,11 @@ Expect walkthroughs, sharp opinions, and experiments straight out of my homelab 
 ## Latest Post
 
 <!--MD_LATEST_POSTS:START-->
-- **2026-02-20** — [Containerizing IBM ACE: A Blog Series - Upgrading in Containers](posts/containerization-series/06.upgrading-in-containers/) · *8 min*
-- **2026-02-17** — [PGP SupportPac on ACE 13.0.6.0: a full end-to-end setup](posts/pgp-node/pgp-node/) · *15 min*
-- **2026-01-18** — [Creating a generic log node using context trees](posts/generic-log-node/generic-log-node/) · *10 min*
-- **2026-01-16** — [ACE v13 new features (when coming from v12)](posts/migrating-ace-to-v13/v13-new-features/) · *16 min*
-- **2026-01-16** — [Running Granite 4.0-1B locally on Android](posts/running-granite-llm-on-android/run-granite-on-android/) · *15 min*
+- **2026-02-20** — [Containerizing IBM ACE: A Blog Series - Upgrading in Containers](posts/containerization-series/06.upgrading-in-containers.md) · *12 min*
+- **2026-02-17** — [PGP SupportPac on ACE 13.0.6.0: a full end-to-end setup](posts/pgp-node/pgp-node.md) · *12 min*
+- **2026-01-18** — [Creating a generic log node using context trees](posts/generic-log-node/generic-log-node.md) · *17 min*
+- **2026-01-16** — [ACE v13 new features (when coming from v12)](posts/migrating-ace-to-v13/v13-new-features.md) · *31 min*
+- **2026-01-16** — [Running Granite 4.0-1B locally on Android](posts/running-granite-llm-on-android/run-granite-on-android.md) · *25 min*
 <!--MD_LATEST_POSTS:END-->
 
 ---

--- a/docs/posts/Ace-Operator-Minikube/installing_ace_minikube.md
+++ b/docs/posts/Ace-Operator-Minikube/installing_ace_minikube.md
@@ -4,14 +4,14 @@ title: 'Installing ACE 13.x on Minikube: Filling in the Blanks'
 image: cover.png
 description: Even though we hardly ever see it, IBM App Connect Enterprise (ACE) is
   perfectly capable of running on plain Kubernetes.
-reading_time: 14 min
+reading_time: 72 min
 ---
 
 ![cover](cover.png){ .md-banner }
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-10-30 · ⏱ 14 min</div>
+  <div class="md-post-meta-left">2025-10-30 · ⏱ 72 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2FAce-Operator-Minikube%2Finstalling_ace_minikube%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/ace-ai-hursley-2025/ace-ai-hursley.md
+++ b/docs/posts/ace-ai-hursley-2025/ace-ai-hursley.md
@@ -2,12 +2,12 @@
 date: '2025-09-05'
 title: ACE, AI, and Why You Should’ve Been in Hursley
 description: IBM TechXchange Early eXperience 2025.
-reading_time: 5 min
+reading_time: 7 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-09-05 · ⏱ 5 min</div>
+  <div class="md-post-meta-left">2025-09-05 · ⏱ 7 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Face-ai-hursley-2025%2Face-ai-hursley%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/archive.md
+++ b/docs/posts/archive.md
@@ -7,60 +7,60 @@ title: Archive
 <!--MD_ARCHIVE:START-->
 ## 2026
 ### February
-- **2026-02-20** — [Containerizing IBM ACE: A Blog Series - Upgrading in Containers](posts/containerization-series/06.upgrading-in-containers/) · *8 min*
-- **2026-02-17** — [PGP SupportPac on ACE 13.0.6.0: a full end-to-end setup](posts/pgp-node/pgp-node/) · *15 min*
+- **2026-02-20** — [Containerizing IBM ACE: A Blog Series - Upgrading in Containers](containerization-series/06.upgrading-in-containers.md) · *12 min*
+- **2026-02-17** — [PGP SupportPac on ACE 13.0.6.0: a full end-to-end setup](pgp-node/pgp-node.md) · *12 min*
 
 ### January
-- **2026-01-18** — [Creating a generic log node using context trees](posts/generic-log-node/generic-log-node/) · *10 min*
-- **2026-01-16** — [ACE v13 new features (when coming from v12)](posts/migrating-ace-to-v13/v13-new-features/) · *16 min*
-- **2026-01-16** — [Running Granite 4.0-1B locally on Android](posts/running-granite-llm-on-android/run-granite-on-android/) · *15 min*
+- **2026-01-18** — [Creating a generic log node using context trees](generic-log-node/generic-log-node.md) · *17 min*
+- **2026-01-16** — [ACE v13 new features (when coming from v12)](migrating-ace-to-v13/v13-new-features.md) · *31 min*
+- **2026-01-16** — [Running Granite 4.0-1B locally on Android](running-granite-llm-on-android/run-granite-on-android.md) · *25 min*
 
 ## 2025
 ### October
-- **2025-10-30** — [Installing ACE 13.x on Minikube: Filling in the Blanks](posts/Ace-Operator-Minikube/installing_ace_minikube/) · *14 min*
-- **2025-10-20** — [IBM TechXchange 2025, Orlando. Overwhelming in all the right ways.](posts/techxchange-2025/techxchange-2025/) · *8 min*
+- **2025-10-30** — [Installing ACE 13.x on Minikube: Filling in the Blanks](Ace-Operator-Minikube/installing_ace_minikube.md) · *72 min*
+- **2025-10-20** — [IBM TechXchange 2025, Orlando. Overwhelming in all the right ways.](techxchange-2025/techxchange-2025.md) · *11 min*
 
 ### September
-- **2025-09-26** — [Containerizing IBM ACE: A Blog Series - Container Startup Optimization](posts/containerization-series/05.ace-startup-optimization/) · *23 min*
-- **2025-09-20** — [Containerizing IBM ACE: A Blog Series - Scoping your runtimes](posts/containerization-series/04.scoping-your-runtime/) · *9 min*
-- **2025-09-11** — [Containerizing IBM ACE: A Blog Series - Images vs Artifacts](posts/containerization-series/02.images-vs-artefacts/) · *7 min*
-- **2025-09-11** — [Containerizing IBM ACE: A Blog Series - Things to Consider in Containers](posts/containerization-series/03.things-to-consider-in-containers/) · *7 min*
-- **2025-09-05** — [ACE, AI, and Why You Should’ve Been in Hursley](posts/ace-ai-hursley-2025/ace-ai-hursley/) · *5 min*
-- **2025-09-02** — [Containerizing IBM ACE: A Blog Series - The Basics](posts/containerization-series/01.the-basics/) · *7 min*
+- **2025-09-26** — [Containerizing IBM ACE: A Blog Series - Container Startup Optimization](containerization-series/05.ace-startup-optimization.md) · *47 min*
+- **2025-09-20** — [Containerizing IBM ACE: A Blog Series - Scoping your runtimes](containerization-series/04.scoping-your-runtime.md) · *13 min*
+- **2025-09-11** — [Containerizing IBM ACE: A Blog Series - Images vs Artifacts](containerization-series/02.images-vs-artefacts.md) · *10 min*
+- **2025-09-11** — [Containerizing IBM ACE: A Blog Series - Things to Consider in Containers](containerization-series/03.things-to-consider-in-containers.md) · *10 min*
+- **2025-09-05** — [ACE, AI, and Why You Should’ve Been in Hursley](ace-ai-hursley-2025/ace-ai-hursley.md) · *7 min*
+- **2025-09-02** — [Containerizing IBM ACE: A Blog Series - The Basics](containerization-series/01.the-basics.md) · *9 min*
 
 ### August
-- **2025-08-29** — [Stop Copying Messages into the Environment: Use Context Tree in ACE 13.0.4.0+](posts/flow-order-context-tree/Stop-Copying-Messages-into-Environment-Use-Context-Tree/) · *7 min*
-- **2025-08-20** — [ACE on Windows:  Disable Weak TLS Ciphers and Verify with OpenSSL](posts/disable-weak-ciphers-ace/ace_disable_weak_ciphers/) · *9 min*
-- **2025-08-18** — [Create JSON Arrays in ESQL and Java (Without Losing Your Sanity)](posts/creating-json-arrays/creating-json-arrays/) · *16 min*
+- **2025-08-29** — [Stop Copying Messages into the Environment: Use Context Tree in ACE 13.0.4.0+](flow-order-context-tree/Stop-Copying-Messages-into-Environment-Use-Context-Tree.md) · *9 min*
+- **2025-08-20** — [ACE on Windows:  Disable Weak TLS Ciphers and Verify with OpenSSL](disable-weak-ciphers-ace/ace_disable_weak_ciphers.md) · *17 min*
+- **2025-08-18** — [Create JSON Arrays in ESQL and Java (Without Losing Your Sanity)](creating-json-arrays/creating-json-arrays.md) · *29 min*
 
 ### July
-- **2025-07-31** — [The EventLogMonitor](posts/eventlogmonitor/eventlogmonitor/) · *2 min*
-- **2025-07-31** — [The Case of the Missing Query Parameters](posts/missing-query-param/missing-query-param/) · *7 min*
+- **2025-07-31** — [The EventLogMonitor](eventlogmonitor/eventlogmonitor.md) · *3 min*
+- **2025-07-31** — [The Case of the Missing Query Parameters](missing-query-param/missing-query-param.md) · *10 min*
 
 ### April
-- **2025-04-04** — [Select The Row](posts/select-the-row/select-the-row/) · *10 min*
+- **2025-04-04** — [Select The Row](select-the-row/select-the-row.md) · *16 min*
 
 ## 2024
 ### November
-- **2024-11-21** — [Automating and Standardizing IBM ACE Installation with PowerShell](posts/automating-standardizing-ace-install-powershell/automating-standardizing-ace-install-powershell/) · *7 min*
+- **2024-11-21** — [Automating and Standardizing IBM ACE Installation with PowerShell](automating-standardizing-ace-install-powershell/automating-standardizing-ace-install-powershell.md) · *10 min*
 
 ### October
-- **2024-10-04** — [Running Unit Tests in IBM App Connect Toolkit Using a Custom Integration Server Setup](posts/toolkit-unit-testing-custom-runtime/toolkit-unit-testing-custom-runtime/) · *5 min*
+- **2024-10-04** — [Running Unit Tests in IBM App Connect Toolkit Using a Custom Integration Server Setup](toolkit-unit-testing-custom-runtime/toolkit-unit-testing-custom-runtime.md) · *8 min*
 
 ### August
-- **2024-08-06** — [How to Customize the IBM App Connect Enterprise Palette: A Quick Guide](posts/customize-ace-palette/customize-ace-palette/) · *3 min*
-- **2024-08-06** — [Ignoring fields in ACE integration testing: a guide](posts/unit-test-ignore/unit-test-ignore/) · *4 min*
-- **2024-08-01** — [A Week at IBM TechXchange Early eXperience Program in Hursley](posts/ace-hursley-2024/ace-hursley-2024/) · *3 min*
+- **2024-08-06** — [How to Customize the IBM App Connect Enterprise Palette: A Quick Guide](customize-ace-palette/customize-ace-palette.md) · *4 min*
+- **2024-08-06** — [Ignoring fields in ACE integration testing: a guide](unit-test-ignore/unit-test-ignore.md) · *4 min*
+- **2024-08-01** — [A Week at IBM TechXchange Early eXperience Program in Hursley](ace-hursley-2024/ace-hursley-2024.md) · *3 min*
 
 ### July
-- **2024-07-22** — [ACE Log Node tips and tricks – default values](posts/log-nodes-tips-tricks/log-node-tips-tricks/) · *4 min*
-- **2024-07-22** — [Logging ACE's ExceptionList Inserts (in the Activity log with the Log node)](posts/logging-ace-exceptionlist/logging-ace-exceptionlist/) · *5 min*
+- **2024-07-22** — [ACE Log Node tips and tricks – default values](log-nodes-tips-tricks/log-node-tips-tricks.md) · *5 min*
+- **2024-07-22** — [Logging ACE's ExceptionList Inserts (in the Activity log with the Log node)](logging-ace-exceptionlist/logging-ace-exceptionlist.md) · *6 min*
 
 ## 2023
 ### September
-- **2023-09-01** — [Transformation Advisor: helpful sidekick or noisy backseat driver?](posts/tad/tad/) · *4 min*
+- **2023-09-01** — [Transformation Advisor: helpful sidekick or noisy backseat driver?](tad/tad.md) · *5 min*
 
 ### May
-- **2023-05-23** — [Business Transaction Monitoring](posts/btm/btm/) · *12 min*
-- **2023-05-23** — [Bar Build Commands: Unraveling the Differences](posts/create-vs-package-bar/create-vs-pacakage-bar/) · *12 min*
+- **2023-05-23** — [Business Transaction Monitoring](btm/btm.md) · *16 min*
+- **2023-05-23** — [Bar Build Commands: Unraveling the Differences](create-vs-package-bar/create-vs-pacakage-bar.md) · *16 min*
 <!--MD_ARCHIVE:END-->

--- a/docs/posts/automating-standardizing-ace-install-powershell/automating-standardizing-ace-install-powershell.md
+++ b/docs/posts/automating-standardizing-ace-install-powershell/automating-standardizing-ace-install-powershell.md
@@ -2,12 +2,12 @@
 date: 2024-11-21
 title: Automating and Standardizing IBM ACE Installation with PowerShell
 description: Automating windows installations of ACE through scripting
-reading_time: 7 min
+reading_time: 10 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2024-11-21 · ⏱ 7 min</div>
+  <div class="md-post-meta-left">2024-11-21 · ⏱ 10 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fautomating-standardizing-ace-install-powershell%2Fautomating-standardizing-ace-install-powershell%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/btm/btm.md
+++ b/docs/posts/btm/btm.md
@@ -3,12 +3,12 @@ date: 2023-05-23
 title: Business Transaction Monitoring
 description: I wanted to try the new (re-introduced in 12.0.2.0) ACE Business Transaction
   Monitoring to see what the added value could be for a company/team/environment that.
-reading_time: 12 min
+reading_time: 16 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2023-05-23 · ⏱ 12 min</div>
+  <div class="md-post-meta-left">2023-05-23 · ⏱ 16 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fbtm%2Fbtm%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/containerization-series/01.the-basics.md
+++ b/docs/posts/containerization-series/01.the-basics.md
@@ -3,14 +3,14 @@ date: 2025-09-02
 title: 'Containerizing IBM ACE: A Blog Series - The Basics'
 description: The first installment in the Containerizing ACE series, tackling the
   basics concepts
-reading_time: 7 min
+reading_time: 9 min
 ---
 
 ![cover](img.png){ .md-banner }
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-09-02 · ⏱ 7 min</div>
+  <div class="md-post-meta-left">2025-09-02 · ⏱ 9 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fcontainerization-series%2F01.the-basics%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/containerization-series/02.images-vs-artefacts.md
+++ b/docs/posts/containerization-series/02.images-vs-artefacts.md
@@ -3,14 +3,14 @@ date: 2025-09-11
 title: 'Containerizing IBM ACE: A Blog Series - Images vs Artifacts'
 description: The seconf installment in the Containerizing ACE series, tackling images
   and artifacts
-reading_time: 7 min
+reading_time: 10 min
 ---
 
 ![cover](img.png){ .md-banner }
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-09-11 · ⏱ 7 min</div>
+  <div class="md-post-meta-left">2025-09-11 · ⏱ 10 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fcontainerization-series%2F02.images-vs-artefacts%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/containerization-series/03.things-to-consider-in-containers.md
+++ b/docs/posts/containerization-series/03.things-to-consider-in-containers.md
@@ -3,14 +3,14 @@ date: 2025-09-11
 title: 'Containerizing IBM ACE: A Blog Series - Things to Consider in Containers'
 description: The third installment in the Containerizing ACE series, tackling some
   container concepts to keep in mind
-reading_time: 7 min
+reading_time: 10 min
 ---
 
 ![cover](img.png){ .md-banner }
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-09-11 · ⏱ 7 min</div>
+  <div class="md-post-meta-left">2025-09-11 · ⏱ 10 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fcontainerization-series%2F03.things-to-consider-in-containers%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/containerization-series/04.scoping-your-runtime.md
+++ b/docs/posts/containerization-series/04.scoping-your-runtime.md
@@ -3,14 +3,14 @@ date: 2025-09-20
 title: 'Containerizing IBM ACE: A Blog Series - Scoping your runtimes'
 description: The fourth installment in the Containerizing ACE series, tackling a number
   of ways to determine your container content
-reading_time: 9 min
+reading_time: 13 min
 ---
 
 ![cover](img.png){ .md-banner }
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-09-20 · ⏱ 9 min</div>
+  <div class="md-post-meta-left">2025-09-20 · ⏱ 13 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fcontainerization-series%2F04.scoping-your-runtime%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/containerization-series/05.ace-startup-optimization.md
+++ b/docs/posts/containerization-series/05.ace-startup-optimization.md
@@ -3,14 +3,14 @@ date: 2025-09-26
 title: 'Containerizing IBM ACE: A Blog Series - Container Startup Optimization'
 description: The fifth installment in the Containerizing ACE series, tackling why
   do ACE containers take so long to boot?.
-reading_time: 23 min
+reading_time: 47 min
 ---
 
 ![cover](img.png){ .md-banner }
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-09-26 · ⏱ 23 min</div>
+  <div class="md-post-meta-left">2025-09-26 · ⏱ 47 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fcontainerization-series%2F05.ace-startup-optimization%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/containerization-series/06.upgrading-in-containers.md
+++ b/docs/posts/containerization-series/06.upgrading-in-containers.md
@@ -3,14 +3,14 @@ date: 2026-02-20
 title: 'Containerizing IBM ACE: A Blog Series - Upgrading in Containers'
 description: The sixth installment in the Containerizing ACE series, tackling why  upgrades
   become boring (in a good way) when you containerize
-reading_time: 8 min
+reading_time: 12 min
 ---
 
 ![cover](img.png){ .md-banner }
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2026-02-20 · ⏱ 8 min</div>
+  <div class="md-post-meta-left">2026-02-20 · ⏱ 12 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fcontainerization-series%2F06.upgrading-in-containers%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/create-vs-package-bar/create-vs-pacakage-bar.md
+++ b/docs/posts/create-vs-package-bar/create-vs-pacakage-bar.md
@@ -4,12 +4,12 @@ title: 'Bar Build Commands: Unraveling the Differences'
 description: Today automated builds and deployments are a must to support business
   demands. IBM App Connect Enterprise (ace) offers strong capabilities to automate
   build and.
-reading_time: 12 min
+reading_time: 16 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2023-05-23 · ⏱ 12 min</div>
+  <div class="md-post-meta-left">2023-05-23 · ⏱ 16 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fcreate-vs-package-bar%2Fcreate-vs-pacakage-bar%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/creating-json-arrays/creating-json-arrays.md
+++ b/docs/posts/creating-json-arrays/creating-json-arrays.md
@@ -2,12 +2,12 @@
 date: 2025-08-18
 title: Create JSON Arrays in ESQL and Java (Without Losing Your Sanity)
 description: How can we properly create clean JSON arrays
-reading_time: 16 min
+reading_time: 29 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-08-18 · ⏱ 16 min</div>
+  <div class="md-post-meta-left">2025-08-18 · ⏱ 29 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fcreating-json-arrays%2Fcreating-json-arrays%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/customize-ace-palette/customize-ace-palette.md
+++ b/docs/posts/customize-ace-palette/customize-ace-palette.md
@@ -2,12 +2,12 @@
 date: 2024-08-06
 title: 'How to Customize the IBM App Connect Enterprise Palette: A Quick Guide'
 description: Keeping a clean workspace
-reading_time: 3 min
+reading_time: 4 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2024-08-06 · ⏱ 3 min</div>
+  <div class="md-post-meta-left">2024-08-06 · ⏱ 4 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fcustomize-ace-palette%2Fcustomize-ace-palette%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/disable-weak-ciphers-ace/ace_disable_weak_ciphers.md
+++ b/docs/posts/disable-weak-ciphers-ace/ace_disable_weak_ciphers.md
@@ -3,14 +3,14 @@ date: 2025-08-20
 title: 'ACE on Windows:  Disable Weak TLS Ciphers and Verify with OpenSSL'
 image: cover.png
 description: Managing your cipher security
-reading_time: 9 min
+reading_time: 17 min
 ---
 
 ![cover](cover.png){ .md-banner }
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-08-20 · ⏱ 9 min</div>
+  <div class="md-post-meta-left">2025-08-20 · ⏱ 17 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fdisable-weak-ciphers-ace%2Face_disable_weak_ciphers%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/eventlogmonitor/eventlogmonitor.md
+++ b/docs/posts/eventlogmonitor/eventlogmonitor.md
@@ -2,12 +2,12 @@
 date: 2025-07-31
 title: The EventLogMonitor
 description: Hyping the EventLogMonitor tool
-reading_time: 2 min
+reading_time: 3 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-07-31 · ⏱ 2 min</div>
+  <div class="md-post-meta-left">2025-07-31 · ⏱ 3 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Feventlogmonitor%2Feventlogmonitor%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/flow-order-context-tree/Stop-Copying-Messages-into-Environment-Use-Context-Tree.md
+++ b/docs/posts/flow-order-context-tree/Stop-Copying-Messages-into-Environment-Use-Context-Tree.md
@@ -2,12 +2,12 @@
 date: 2025-08-29
 title: 'Stop Copying Messages into the Environment: Use Context Tree in ACE 13.0.4.0+'
 description: Using the new context tree in an actual functional use case
-reading_time: 7 min
+reading_time: 9 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-08-29 · ⏱ 7 min</div>
+  <div class="md-post-meta-left">2025-08-29 · ⏱ 9 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fflow-order-context-tree%2FStop-Copying-Messages-into-Environment-Use-Context-Tree%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/generic-log-node/generic-log-node.md
+++ b/docs/posts/generic-log-node/generic-log-node.md
@@ -3,14 +3,14 @@ date: 2026-01-18
 title: Creating a generic log node using context trees
 image: cover.png
 description: Using the Context Tree in a second real life use case, logging
-reading_time: 10 min
+reading_time: 17 min
 ---
 
 ![cover](cover.png){ .md-banner }
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2026-01-18 · ⏱ 10 min</div>
+  <div class="md-post-meta-left">2026-01-18 · ⏱ 17 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fgeneric-log-node%2Fgeneric-log-node%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/index.md
+++ b/docs/posts/index.md
@@ -6,33 +6,33 @@
 # Posts
 
 <!--MD_ALL_POSTS:START-->
-- **2026-02-20** — [Containerizing IBM ACE: A Blog Series - Upgrading in Containers](posts/containerization-series/06.upgrading-in-containers/) · *8 min*
-- **2026-02-17** — [PGP SupportPac on ACE 13.0.6.0: a full end-to-end setup](posts/pgp-node/pgp-node/) · *15 min*
-- **2026-01-18** — [Creating a generic log node using context trees](posts/generic-log-node/generic-log-node/) · *10 min*
-- **2026-01-16** — [ACE v13 new features (when coming from v12)](posts/migrating-ace-to-v13/v13-new-features/) · *16 min*
-- **2026-01-16** — [Running Granite 4.0-1B locally on Android](posts/running-granite-llm-on-android/run-granite-on-android/) · *15 min*
-- **2025-10-30** — [Installing ACE 13.x on Minikube: Filling in the Blanks](posts/Ace-Operator-Minikube/installing_ace_minikube/) · *14 min*
-- **2025-10-20** — [IBM TechXchange 2025, Orlando. Overwhelming in all the right ways.](posts/techxchange-2025/techxchange-2025/) · *8 min*
-- **2025-09-26** — [Containerizing IBM ACE: A Blog Series - Container Startup Optimization](posts/containerization-series/05.ace-startup-optimization/) · *23 min*
-- **2025-09-20** — [Containerizing IBM ACE: A Blog Series - Scoping your runtimes](posts/containerization-series/04.scoping-your-runtime/) · *9 min*
-- **2025-09-11** — [Containerizing IBM ACE: A Blog Series - Images vs Artifacts](posts/containerization-series/02.images-vs-artefacts/) · *7 min*
-- **2025-09-11** — [Containerizing IBM ACE: A Blog Series - Things to Consider in Containers](posts/containerization-series/03.things-to-consider-in-containers/) · *7 min*
-- **2025-09-05** — [ACE, AI, and Why You Should’ve Been in Hursley](posts/ace-ai-hursley-2025/ace-ai-hursley/) · *5 min*
-- **2025-09-02** — [Containerizing IBM ACE: A Blog Series - The Basics](posts/containerization-series/01.the-basics/) · *7 min*
-- **2025-08-29** — [Stop Copying Messages into the Environment: Use Context Tree in ACE 13.0.4.0+](posts/flow-order-context-tree/Stop-Copying-Messages-into-Environment-Use-Context-Tree/) · *7 min*
-- **2025-08-20** — [ACE on Windows:  Disable Weak TLS Ciphers and Verify with OpenSSL](posts/disable-weak-ciphers-ace/ace_disable_weak_ciphers/) · *9 min*
-- **2025-08-18** — [Create JSON Arrays in ESQL and Java (Without Losing Your Sanity)](posts/creating-json-arrays/creating-json-arrays/) · *16 min*
-- **2025-07-31** — [The EventLogMonitor](posts/eventlogmonitor/eventlogmonitor/) · *2 min*
-- **2025-07-31** — [The Case of the Missing Query Parameters](posts/missing-query-param/missing-query-param/) · *7 min*
-- **2025-04-04** — [Select The Row](posts/select-the-row/select-the-row/) · *10 min*
-- **2024-11-21** — [Automating and Standardizing IBM ACE Installation with PowerShell](posts/automating-standardizing-ace-install-powershell/automating-standardizing-ace-install-powershell/) · *7 min*
-- **2024-10-04** — [Running Unit Tests in IBM App Connect Toolkit Using a Custom Integration Server Setup](posts/toolkit-unit-testing-custom-runtime/toolkit-unit-testing-custom-runtime/) · *5 min*
-- **2024-08-06** — [How to Customize the IBM App Connect Enterprise Palette: A Quick Guide](posts/customize-ace-palette/customize-ace-palette/) · *3 min*
-- **2024-08-06** — [Ignoring fields in ACE integration testing: a guide](posts/unit-test-ignore/unit-test-ignore/) · *4 min*
-- **2024-08-01** — [A Week at IBM TechXchange Early eXperience Program in Hursley](posts/ace-hursley-2024/ace-hursley-2024/) · *3 min*
-- **2024-07-22** — [ACE Log Node tips and tricks – default values](posts/log-nodes-tips-tricks/log-node-tips-tricks/) · *4 min*
-- **2024-07-22** — [Logging ACE's ExceptionList Inserts (in the Activity log with the Log node)](posts/logging-ace-exceptionlist/logging-ace-exceptionlist/) · *5 min*
-- **2023-09-01** — [Transformation Advisor: helpful sidekick or noisy backseat driver?](posts/tad/tad/) · *4 min*
-- **2023-05-23** — [Business Transaction Monitoring](posts/btm/btm/) · *12 min*
-- **2023-05-23** — [Bar Build Commands: Unraveling the Differences](posts/create-vs-package-bar/create-vs-pacakage-bar/) · *12 min*
+- **2026-02-20** — [Containerizing IBM ACE: A Blog Series - Upgrading in Containers](containerization-series/06.upgrading-in-containers.md) · *12 min*
+- **2026-02-17** — [PGP SupportPac on ACE 13.0.6.0: a full end-to-end setup](pgp-node/pgp-node.md) · *12 min*
+- **2026-01-18** — [Creating a generic log node using context trees](generic-log-node/generic-log-node.md) · *17 min*
+- **2026-01-16** — [ACE v13 new features (when coming from v12)](migrating-ace-to-v13/v13-new-features.md) · *31 min*
+- **2026-01-16** — [Running Granite 4.0-1B locally on Android](running-granite-llm-on-android/run-granite-on-android.md) · *25 min*
+- **2025-10-30** — [Installing ACE 13.x on Minikube: Filling in the Blanks](Ace-Operator-Minikube/installing_ace_minikube.md) · *72 min*
+- **2025-10-20** — [IBM TechXchange 2025, Orlando. Overwhelming in all the right ways.](techxchange-2025/techxchange-2025.md) · *11 min*
+- **2025-09-26** — [Containerizing IBM ACE: A Blog Series - Container Startup Optimization](containerization-series/05.ace-startup-optimization.md) · *47 min*
+- **2025-09-20** — [Containerizing IBM ACE: A Blog Series - Scoping your runtimes](containerization-series/04.scoping-your-runtime.md) · *13 min*
+- **2025-09-11** — [Containerizing IBM ACE: A Blog Series - Images vs Artifacts](containerization-series/02.images-vs-artefacts.md) · *10 min*
+- **2025-09-11** — [Containerizing IBM ACE: A Blog Series - Things to Consider in Containers](containerization-series/03.things-to-consider-in-containers.md) · *10 min*
+- **2025-09-05** — [ACE, AI, and Why You Should’ve Been in Hursley](ace-ai-hursley-2025/ace-ai-hursley.md) · *7 min*
+- **2025-09-02** — [Containerizing IBM ACE: A Blog Series - The Basics](containerization-series/01.the-basics.md) · *9 min*
+- **2025-08-29** — [Stop Copying Messages into the Environment: Use Context Tree in ACE 13.0.4.0+](flow-order-context-tree/Stop-Copying-Messages-into-Environment-Use-Context-Tree.md) · *9 min*
+- **2025-08-20** — [ACE on Windows:  Disable Weak TLS Ciphers and Verify with OpenSSL](disable-weak-ciphers-ace/ace_disable_weak_ciphers.md) · *17 min*
+- **2025-08-18** — [Create JSON Arrays in ESQL and Java (Without Losing Your Sanity)](creating-json-arrays/creating-json-arrays.md) · *29 min*
+- **2025-07-31** — [The EventLogMonitor](eventlogmonitor/eventlogmonitor.md) · *3 min*
+- **2025-07-31** — [The Case of the Missing Query Parameters](missing-query-param/missing-query-param.md) · *10 min*
+- **2025-04-04** — [Select The Row](select-the-row/select-the-row.md) · *16 min*
+- **2024-11-21** — [Automating and Standardizing IBM ACE Installation with PowerShell](automating-standardizing-ace-install-powershell/automating-standardizing-ace-install-powershell.md) · *10 min*
+- **2024-10-04** — [Running Unit Tests in IBM App Connect Toolkit Using a Custom Integration Server Setup](toolkit-unit-testing-custom-runtime/toolkit-unit-testing-custom-runtime.md) · *8 min*
+- **2024-08-06** — [How to Customize the IBM App Connect Enterprise Palette: A Quick Guide](customize-ace-palette/customize-ace-palette.md) · *4 min*
+- **2024-08-06** — [Ignoring fields in ACE integration testing: a guide](unit-test-ignore/unit-test-ignore.md) · *4 min*
+- **2024-08-01** — [A Week at IBM TechXchange Early eXperience Program in Hursley](ace-hursley-2024/ace-hursley-2024.md) · *3 min*
+- **2024-07-22** — [ACE Log Node tips and tricks – default values](log-nodes-tips-tricks/log-node-tips-tricks.md) · *5 min*
+- **2024-07-22** — [Logging ACE's ExceptionList Inserts (in the Activity log with the Log node)](logging-ace-exceptionlist/logging-ace-exceptionlist.md) · *6 min*
+- **2023-09-01** — [Transformation Advisor: helpful sidekick or noisy backseat driver?](tad/tad.md) · *5 min*
+- **2023-05-23** — [Business Transaction Monitoring](btm/btm.md) · *16 min*
+- **2023-05-23** — [Bar Build Commands: Unraveling the Differences](create-vs-package-bar/create-vs-pacakage-bar.md) · *16 min*
 <!--MD_ALL_POSTS:END-->

--- a/docs/posts/log-nodes-tips-tricks/log-node-tips-tricks.md
+++ b/docs/posts/log-nodes-tips-tricks/log-node-tips-tricks.md
@@ -2,12 +2,12 @@
 date: 2024-07-22
 title: ACE Log Node tips and tricks – default values
 description: Utilizing JSONata in the new Log Node
-reading_time: 4 min
+reading_time: 5 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2024-07-22 · ⏱ 4 min</div>
+  <div class="md-post-meta-left">2024-07-22 · ⏱ 5 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Flog-nodes-tips-tricks%2Flog-node-tips-tricks%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/logging-ace-exceptionlist/logging-ace-exceptionlist.md
+++ b/docs/posts/logging-ace-exceptionlist/logging-ace-exceptionlist.md
@@ -3,12 +3,12 @@ date: 2024-07-22
 title: Logging ACE's ExceptionList Inserts (in the Activity log with the Log node)
 description: Properly handing and parsing the ACE Exception list to retreive the most
   usefull information (with JSONata)
-reading_time: 5 min
+reading_time: 6 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2024-07-22 · ⏱ 5 min</div>
+  <div class="md-post-meta-left">2024-07-22 · ⏱ 6 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Flogging-ace-exceptionlist%2Flogging-ace-exceptionlist%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/migrating-ace-to-v13/v13-new-features.md
+++ b/docs/posts/migrating-ace-to-v13/v13-new-features.md
@@ -3,14 +3,14 @@ date: 2026-01-16
 title: ACE v13 new features (when coming from v12)
 image: cover.png
 description: A summary of all the new features for ACE v13 up to 13.0.6.0
-reading_time: 16 min
+reading_time: 31 min
 ---
 
 ![cover](cover.png){ .md-banner }
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2026-01-16 · ⏱ 16 min</div>
+  <div class="md-post-meta-left">2026-01-16 · ⏱ 31 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fmigrating-ace-to-v13%2Fv13-new-features%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/missing-query-param/missing-query-param.md
+++ b/docs/posts/missing-query-param/missing-query-param.md
@@ -3,12 +3,12 @@ date: 2025-07-31
 title: The Case of the Missing Query Parameters
 description: Aka “The Blog That Reads like an Agatha Christie Story” or “The Overly
   Dramatic Description of a Simple Problem“.
-reading_time: 7 min
+reading_time: 10 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-07-31 · ⏱ 7 min</div>
+  <div class="md-post-meta-left">2025-07-31 · ⏱ 10 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fmissing-query-param%2Fmissing-query-param%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/pgp-node/pgp-node.md
+++ b/docs/posts/pgp-node/pgp-node.md
@@ -18,6 +18,7 @@ reading_time: 12 min
 
 <!--MD_POST_META:END-->
 
+
 # PGP SupportPac on ACE: a full end-to-end setup
 
 > **Tested on ACE 13.0.6.0**

--- a/docs/posts/pgp-node/pgp-node.md
+++ b/docs/posts/pgp-node/pgp-node.md
@@ -4,14 +4,14 @@ title: 'PGP SupportPac on ACE 13.0.6.0: a full end-to-end setup'
 description: A practical, field-tested setup of the PGP SupportPac on ACE 13.0.6.0,
   from key generation to working encryption and decryption flows, including the runtime
   jar details that tend to get missed.
-reading_time: 15 min
+reading_time: 12 min
 ---
 
 ![cover](cover.png){ .md-banner }
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2026-02-17 · ⏱ 15 min</div>
+  <div class="md-post-meta-left">2026-02-17 · ⏱ 12 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fpgp-node%2Fpgp-node%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>
@@ -21,7 +21,6 @@ reading_time: 15 min
 # PGP SupportPac on ACE: a full end-to-end setup
 
 > **Tested on ACE 13.0.6.0**
-
 
 Ever spent two hours wiring PGP in ACE only to hit a `NoClassDefFoundError` and question your life choices?  
 I know I have. And I maintain the damn thing.

--- a/docs/posts/running-granite-llm-on-android/run-granite-on-android.md
+++ b/docs/posts/running-granite-llm-on-android/run-granite-on-android.md
@@ -4,7 +4,7 @@ description: An LLM that runs locally on your phone, I've got to give that a try
 date: 2026-01-16
 author: Matthias Blomme
 image: cover.png
-reading_time: 15 min
+reading_time: 25 min
 tags:
 - granite
 - IBM
@@ -18,7 +18,7 @@ tags:
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">Matthias Blomme · 2026-01-16 · ⏱ 15 min</div>
+  <div class="md-post-meta-left">Matthias Blomme · 2026-01-16 · ⏱ 25 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Frunning-granite-llm-on-android%2Frun-granite-on-android%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/select-the-row/select-the-row.md
+++ b/docs/posts/select-the-row/select-the-row.md
@@ -3,12 +3,12 @@ date: 2025-04-04
 title: Select The Row
 description: Let’s talk about SELECT in ESQL — and I don’t mean database queries (although
   they are rather similar)
-reading_time: 10 min
+reading_time: 16 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-04-04 · ⏱ 10 min</div>
+  <div class="md-post-meta-left">2025-04-04 · ⏱ 16 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Fselect-the-row%2Fselect-the-row%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/tad/tad.md
+++ b/docs/posts/tad/tad.md
@@ -2,12 +2,12 @@
 date: 2023-09-01
 title: 'Transformation Advisor: helpful sidekick or noisy backseat driver?'
 description: Prepare your ACE migration
-reading_time: 4 min
+reading_time: 5 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2023-09-01 · ⏱ 4 min</div>
+  <div class="md-post-meta-left">2023-09-01 · ⏱ 5 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Ftad%2Ftad%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/techxchange-2025/techxchange-2025.md
+++ b/docs/posts/techxchange-2025/techxchange-2025.md
@@ -2,12 +2,12 @@
 date: 2025-10-20
 title: IBM TechXchange 2025, Orlando. Overwhelming in all the right ways.
 description: TechXchange 2025, what you missed
-reading_time: 8 min
+reading_time: 11 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2025-10-20 · ⏱ 8 min</div>
+  <div class="md-post-meta-left">2025-10-20 · ⏱ 11 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Ftechxchange-2025%2Ftechxchange-2025%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/docs/posts/toolkit-unit-testing-custom-runtime/toolkit-unit-testing-custom-runtime.md
+++ b/docs/posts/toolkit-unit-testing-custom-runtime/toolkit-unit-testing-custom-runtime.md
@@ -4,12 +4,12 @@ title: Running Unit Tests in IBM App Connect Toolkit Using a Custom Integration 
   Setup
 description: When working with IBM App Connect Toolkit, running unit tests on integration
   flows with custom configurations can be quite challenging.
-reading_time: 5 min
+reading_time: 8 min
 ---
 
 <!--MD_POST_META:START-->
 <div class="md-post-meta">
-  <div class="md-post-meta-left">2024-10-04 · ⏱ 5 min</div>
+  <div class="md-post-meta-left">2024-10-04 · ⏱ 8 min</div>
   <div class="md-post-meta-right"><span class="post-share-label">Share:</span> <a class="post-share post-share-linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fmatthiasblomme.github.io%2Fblogs%2Fposts%2Ftoolkit-unit-testing-custom-runtime%2Ftoolkit-unit-testing-custom-runtime%2F" target="_blank" rel="noopener" title="Share on LinkedIn">[<span class="in">in</span>]</a></div>
 </div>
 <hr class="md-post-divider"/>

--- a/scripts/gen_posts.py
+++ b/scripts/gen_posts.py
@@ -28,7 +28,8 @@ ALLPOSTS_END = "<!--MD_ALL_POSTS:END-->"
 ARCHIVE_START = "<!--MD_ARCHIVE:START-->"
 ARCHIVE_END   = "<!--MD_ARCHIVE:END-->"
 
-WORDS_PER_MINUTE = 200
+WORDS_PER_MINUTE = 130
+CODE_WORDS_PER_MINUTE = 75
 MIN_READING_MINUTES = 1
 
 # Files in POSTS_DIR that are index/meta pages, not posts
@@ -141,10 +142,18 @@ def strip_markdown(text: str) -> str:
 
 
 def estimate_reading_time_minutes(md_body: str) -> int:
+    # Extract fenced code block content before stripping
+    code_blocks = re.findall(r"```.*?```", md_body, flags=re.DOTALL)
+    code_words = re.findall(r"\b\w+\b", " ".join(code_blocks))
+
+    # Strip everything (incl. code blocks) for prose word count
     cleaned = strip_markdown(md_body)
-    words = re.findall(r"\b\w+\b", cleaned)
-    minutes = max(MIN_READING_MINUTES, int(round(len(words) / WORDS_PER_MINUTE)))
-    return minutes
+    prose_words = re.findall(r"\b\w+\b", cleaned)
+
+    prose_minutes = len(prose_words) / WORDS_PER_MINUTE
+    code_minutes = len(code_words) / CODE_WORDS_PER_MINUTE
+
+    return max(MIN_READING_MINUTES, int(round(prose_minutes + code_minutes)))
 
 
 def format_reading_time(minutes: int) -> str:
@@ -384,7 +393,8 @@ def update_archive_page(posts: list[Post], verbose: bool = False):
 # -----------------------------------------------------------------------------
 # Per-post processing
 # -----------------------------------------------------------------------------
-def process_post(site_url: str, md_path: Path, verbose: bool = False) -> bool:
+def process_post(site_url: str, md_path: Path, verbose: bool = False,
+                 recalculate_reading_time: bool = False) -> bool:
     """
     Processes a single post: ensures reading_time, injects meta block.
     Returns True if the file was written, False if unchanged (skipped).
@@ -395,7 +405,7 @@ def process_post(site_url: str, md_path: Path, verbose: bool = False) -> bool:
         return False
 
     # Ensure reading_time exists (compute if missing; preserve if already set)
-    if not fm.get("reading_time"):
+    if not fm.get("reading_time") or recalculate_reading_time:
         mins = estimate_reading_time_minutes(body)
         fm["reading_time"] = format_reading_time(mins)
 
@@ -433,6 +443,11 @@ def main():
         action="store_true",
         help="Print per-file status (skipped vs written).",
     )
+    parser.add_argument(
+        "--recalculate-reading-time", "-R",
+        action="store_true",
+        help="Force recalculate reading_time for all posts (ignores existing values).",
+    )
     args = parser.parse_args()
     verbose = args.verbose
 
@@ -443,7 +458,8 @@ def main():
     for md in POSTS_DIR.rglob("*.md"):
         if md.name.lower() in _SKIP_NAMES:
             continue
-        if process_post(site_url, md, verbose=verbose):
+        if process_post(site_url, md, verbose=verbose,
+                        recalculate_reading_time=args.recalculate_reading_time):
             written += 1
         else:
             skipped += 1

--- a/scripts/gen_posts.py
+++ b/scripts/gen_posts.py
@@ -282,9 +282,11 @@ def collect_posts(site_url: str) -> list[Post]:
             mins = estimate_reading_time_minutes(body)
             rt = format_reading_time(mins)
 
-        # rel_url for mkdocs internal links (use directory urls)
-        rel = md.resolve().relative_to(DOCS_DIR.resolve())
-        rel_url = rel.with_suffix("").as_posix() + "/"
+        # rel_url relative to POSTS_DIR (e.g. "pgp-node/pgp-node.md")
+        # render_latest_posts prefixes "posts/" for the root index;
+        # render_all_posts / render_archive use it as-is (they live in POSTS_DIR)
+        rel = md.resolve().relative_to(POSTS_DIR.resolve())
+        rel_url = rel.as_posix()
 
         posts.append(
             Post(
@@ -315,16 +317,18 @@ def replace_between_markers(text: str, start: str, end: str, replacement: str) -
 
 
 def render_latest_posts(posts: list[Post], limit: int = 5) -> str:
+    # Lives in docs/index.md — links need "posts/" prefix relative to docs root
     lines = []
     for p in posts[:limit]:
-        lines.append(f"- **{p.date_display}** — [{p.title}]({p.rel_url}) · *{p.reading_time}*")
+        lines.append(f"- **{p.date_display}** — [{p.title}](posts/{p.rel_url}) · *{p.reading_time}*")
     return "\n".join(lines) if lines else "_No posts yet._"
 
 
-def render_all_posts(posts: list[Post]) -> str:
+def render_all_posts(posts: list[Post], prefix: str = "") -> str:
+    # prefix="" for docs/posts/index.md; prefix="posts/" if ever used from docs root
     lines = []
     for p in posts:
-        lines.append(f"- **{p.date_display}** — [{p.title}]({p.rel_url}) · *{p.reading_time}*")
+        lines.append(f"- **{p.date_display}** — [{p.title}]({prefix}{p.rel_url}) · *{p.reading_time}*")
     return "\n".join(lines) if lines else "_No posts yet._"
 
 
@@ -367,8 +371,10 @@ def update_index_pages(posts: list[Post]):
         posts_overview = POSTS_DIR / "index.md"
 
     if posts_overview.exists():
+        # If the overview is at docs root level, prefix links with "posts/"
+        prefix = "posts/" if posts_overview.parent == DOCS_DIR else ""
         txt = posts_overview.read_text(encoding="utf-8")
-        txt = replace_between_markers(txt, ALLPOSTS_START, ALLPOSTS_END, render_all_posts(posts))
+        txt = replace_between_markers(txt, ALLPOSTS_START, ALLPOSTS_END, render_all_posts(posts, prefix=prefix))
         posts_overview.write_text(txt, encoding="utf-8")
 
 


### PR DESCRIPTION
## Summary

- **Reading time**: Lower WPM from 200 → 130 (standard for technical content) and count fenced code blocks at 75 WPM instead of stripping them entirely. Adds `--recalculate-reading-time` / `-R` flag to force-update existing posts. All 27 posts recalculated.
- **Link fix**: Generated index/archive links were using a docs-root-relative path for all output files, causing MkDocs to warn about unresolved links in `posts/index.md` and `posts/archive.md`. Links are now correctly resolved relative to each output file's location — zero warnings in `mkdocs build`.

## Test plan
- [ ] `mkdocs build` produces no WARNING or unrecognized-link messages
- [ ] Links in home page, posts index, and archive all navigate to correct posts
- [ ] Reading times on posts feel more realistic for technical content

🤖 Generated with [Claude Code](https://claude.com/claude-code)